### PR TITLE
Fix README and default Anchor version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: IhorMuliar/setup-anchor@v1
+      - uses: IhorMuliar/setup-anchor-environment@v1
       - run: anchor build
         shell: bash
 ```
@@ -24,11 +24,11 @@ This will use the default versions of Node.js, the Solana CLI tools and Anchor, 
 ```yaml
 steps:
   - uses: actions/checkout@v4
-  - uses: IhorMuliar/setup-anchor@v1
+  - uses: IhorMuliar/setup-anchor-environment@v1
     with:
       node-version: '22.14.0'
       solana-cli-version: '2.2.3'
-      anchor-version: '0.31.0'
+      anchor-version: '0.31.1'
       workspace-dir: 'app'
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   anchor-version:
     description: 'Version of Anchor to use'
     required: false
-    default: '0.31.0'
+    default: '0.31.1'
   workspace-dir:
     description: 'Anchor workspace directory'
     required: false


### PR DESCRIPTION
1. The name of the action is missing the `-environment` postfix in the README.
2. Update the default Anchor version to 0.31.1, which contains a bug fix.